### PR TITLE
code(2_Urban_District_Upscaling.py): bug-fix: file save was not possible

### DIFF
--- a/program_files/GUI_st/pages/2_Urban_District_Upscaling.py
+++ b/program_files/GUI_st/pages/2_Urban_District_Upscaling.py
@@ -168,8 +168,8 @@ def us_application_start_download() -> None:
     """
 
     # # set the result path based on the gui_st_settings.json
-    # res_folder_path = os.path.join(set_result_path(),
-    #                                'Upscaling_Tool')
+    res_folder_path = os.path.join(set_result_path(),
+                                   'Upscaling_Tool')
 
     # # Check if the results folder path exists
     # if os.path.exists(res_folder_path) is False:


### PR DESCRIPTION
By using the original file, It wasn't possible to save a model definition created by the upscaling tool. The following error message was caused:

```
File "C:\Users\xxxxxx\program_files\GUI_st\pages\2_Urban_District_Upscaling.py", line 175, in us_application_start_download
    if os.path.exists(res_folder_path) is False:
NameError: name 'res_folder_path' is not defined
```

By reintegrating the code section in the comments, it was possible for me to save the file.

However, I am not sure why the code section was initially excluded and whether the change affects other functionalities.